### PR TITLE
ci(release): add permissions for OIDC and npm provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,15 +3,21 @@ name: release
   push:
     branches:
       - main
+permissions:
+  id-token: write # to enable use of OIDC for trusted publishing and npm provenance
+  contents: write # tags and releases
+  pull-requests: write # comments
+  issues: write # comments
+
 jobs:
   release:
     name: release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GR2M_PAT }}
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: lts/*
       - run: npm ci


### PR DESCRIPTION
Enables npm provenance via OIDC trusted publishing. Removes `NPM_TOKEN` dependency.

See https://github.com/gr2m/semantic-release-plugin-update-version-in-files/pull/62 for reference.