### PR TITLE
ci: fix publishTest to pass --tag for prerelease

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       - run: npm set //registry.npmjs.org/:_authToken $NPM_TOKEN
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN}}
-      - run: npm publish
+      - run: npm publish --tag test
         id: publish
         working-directory: ./test/test-package
       - uses: ./


### PR DESCRIPTION
## Problem

The `publishTest` job has been failing on all recent PRs (including dependabot PRs #262, #263, #265, #267) with:

```
npm error You must specify a tag using --tag when publishing a prerelease version.
```

## Cause

`test/test-package/prepare.js` runs as `prepublishOnly` and rewrites the version to a prerelease (`1.0.0-test-<timestamp>`). Recent npm versions refuse to publish prereleases without an explicit `--tag`, since otherwise the prerelease would clobber the `latest` dist-tag.

## Fix

Pass `--tag test` to `npm publish` in the `publishTest` workflow step. This is a throwaway test package, so an isolated `test` dist-tag avoids polluting `latest`.

```diff
-      - run: npm publish
+      - run: npm publish --tag test
         id: publish
         working-directory: ./test/test-package
```

## Notes

- `publishTest` is a required status check on `main`, so this fix is needed to unblock the dependabot PRs.
- Minimal change; nothing else touched.